### PR TITLE
Only persist dist in sdist CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - persist_to_workspace:
           root: "~"
           paths:
-            - repo
+            - repo/dist
 
   upload-pypi:
     executor: ubuntu-builder


### PR DESCRIPTION
There was an issue that build-sdist and install persisted the same files
to the workspace. This should fix this.